### PR TITLE
Fix Viewport3DTest mesh ref typing

### DIFF
--- a/apps/explorer/src/Viewport3DTest.tsx
+++ b/apps/explorer/src/Viewport3DTest.tsx
@@ -1,8 +1,10 @@
-import { useRef } from 'react';
-import { useFrame } from '@react-three/fiber'
+import { useRef, type MutableRefObject } from 'react';
+import { useFrame } from '@react-three/fiber';
+import type { Mesh } from 'three';
+import type * as THREE from 'three';
 
 export function Viewport3DTest() {
-  const myMesh = useRef()
+  const myMesh = useRef<THREE.Mesh>(null!) as MutableRefObject<Mesh>;
 
   useFrame(({ clock }) => {
     myMesh.current.rotation.x = clock.elapsedTime


### PR DESCRIPTION
## Summary
- type the mesh ref in `Viewport3DTest`
- import `Mesh` and `THREE` types from `three`
- use typed `MutableRefObject`

## Testing
- `pnpm exec tsc -p apps/explorer/tsconfig.app.json`

------
https://chatgpt.com/codex/tasks/task_e_687be248b97c8329ae10d5fe63aa57a4