### PR TITLE
Configure API base via environment variable

### DIFF
--- a/apps/explorer/vite.config.ts
+++ b/apps/explorer/vite.config.ts
@@ -1,15 +1,21 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 import path from "node:path";
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
-  resolve: {
-    alias: {
-      "@repo/lib": path.resolve(__dirname, "../../packages/lib/src"),
-      "@repo/types": path.resolve(__dirname, "../../packages/types"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    plugins: [react(), tsconfigPaths()],
+    resolve: {
+      alias: {
+        "@repo/lib": path.resolve(__dirname, "../../packages/lib/src"),
+        "@repo/types": path.resolve(__dirname, "../../packages/types"),
+      },
     },
-  },
+    define: {
+      "process.env.API_BASE": JSON.stringify(env.API_BASE ?? "http://localhost:3000"),
+    },
+  };
 });

--- a/packages/lib/src/api/cultural-object.ts
+++ b/packages/lib/src/api/cultural-object.ts
@@ -1,6 +1,7 @@
 import type { CulturalObject } from "@repo/types";
 
-const API_BASE = "http://localhost:3000";
+const API_BASE =
+  process.env.API_BASE ?? "http://localhost:3000";
 
 //create
 export async function createCulturalObject(data: {


### PR DESCRIPTION
## Summary
- make API base configurable via `process.env.API_BASE`
- inject the variable in the explorer Vite config
- revert README changes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687bf878d59c8329b897c4f678e57176